### PR TITLE
fix: async_forward_entry_setup is deprecated

### DIFF
--- a/custom_components/ambeo_soundbar/__init__.py
+++ b/custom_components/ambeo_soundbar/__init__.py
@@ -62,8 +62,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
          model=model,
          sw_version=version)
 
-    hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, "media_player"))
-    hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, "switch"))
-    hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, "light"))
-    hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, "button"))
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setups(
+            entry, ["media_player", "switch", "light", "button"]
+        )
+    )
     return True


### PR DESCRIPTION
Calling hass.config_entries.async_forward_entry_setup is deprecated and will be removed in Home Assistant 2025.6. Instead, await hass.config_entries.async_forward_entry_setups as it can load multiple platforms at once and is more efficient since it does not require a separate import executor job for each platform.

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/