### PR TITLE
feat: add zeroconf discovery support

### DIFF
--- a/PR_STRATEGY.md
+++ b/PR_STRATEGY.md
@@ -1,0 +1,66 @@
+# Stratégie de PRs vers l'upstream
+
+## Plan de découpage
+
+### PR 1 : Zeroconf Discovery (Petite, facile à merger)
+**Fichiers concernés :**
+- `manifest.json` - ajout zeroconf
+- `config_flow.py` - découverte automatique
+- `__init__.py` - support discovery
+
+**Valeur :** Feature visible et testable facilement
+
+---
+
+### PR 2 : Coordinator + Diagnostics (Architecture)
+**Fichiers concernés :**
+- `coordinator.py` (nouveau)
+- `diagnostics.py` (nouveau)
+- `__init__.py` - intégration coordinator
+- `entity.py` - utilisation coordinator
+- `const.py` - constantes
+
+**Valeur :** Améliore performance et débogage
+
+---
+
+### PR 3 : Services & Select Entities (Features)
+**Fichiers concernés :**
+- `services.yaml` (nouveau)
+- `select.py` (nouveau)
+- `__init__.py` - register services
+- Translations mises à jour
+
+**Valeur :** Nouvelles fonctionnalités utilisateur
+
+---
+
+### PR 4 : CI/CD + Dev Tools (Infra)
+**Fichiers concernés :**
+- `.github/workflows/` complets
+- `.pre-commit-config.yaml`
+- `CONTRIBUTING.md`
+- `SETUP_DEVELOPMENT.md`
+- `Makefile`
+- `requirements_test.txt`
+- `CHANGELOG.md`
+
+**Valeur :** Qualité et maintenance
+
+---
+
+## Ordre recommandé
+
+1. **PR 1** (Zeroconf) → Facile, feature visible
+2. **PR 2** (Coordinator) → Fondation technique
+3. **PR 3** (Services) → Features utilisateur
+4. **PR 4** (CI/CD) → Infrastructure
+
+## Pourquoi pas tout en une ?
+
+- ❌ Difficile à reviewer (1000+ lignes)
+- ❌ Risque de conflits
+- ❌ Une erreur bloque tout
+- ✅ Petites PRs = merge rapide
+- ✅ Feedback plus rapide
+- ✅ Historique propre

--- a/custom_components/ambeo_soundbar/config_flow.py
+++ b/custom_components/ambeo_soundbar/config_flow.py
@@ -1,10 +1,19 @@
 import logging
-import voluptuous as vol
-import aiohttp
 
+import aiohttp
 from homeassistant import config_entries
-from .const import CONFIG_DEBOUNCE_COOLDOWN_DEFAULT, CONFIG_HOST_DEFAULT, DOMAIN, DEFAULT_PORT, CONFIG_HOST, CONFIG_DEBOUNCE_COOLDOWN
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+import voluptuous as vol
+
 from .api.factory import AmbeoAPIFactory
+from .const import (
+    CONFIG_DEBOUNCE_COOLDOWN,
+    CONFIG_DEBOUNCE_COOLDOWN_DEFAULT,
+    CONFIG_HOST,
+    CONFIG_HOST_DEFAULT,
+    DEFAULT_PORT,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,13 +23,15 @@ async def validate_connection(hass, host, port=DEFAULT_PORT):
     async with aiohttp.ClientSession() as client_session:
         try:
             ambeo_api = await AmbeoAPIFactory.create_api(
-                host, port, client_session, hass)
+                host, port, client_session, hass
+            )
             name = await ambeo_api.get_name()
             serial = await ambeo_api.get_serial()
-            return name, serial, None
         except Exception as error:
-            _LOGGER.error("Connection error to %s: %s", host, error)
+            _LOGGER.exception("Connection error to %s: %s", host, error)
             return None, None, "cannot_connect"
+        else:
+            return name, serial, None
 
 
 class AmbeoOptionsFlowHandler(config_entries.OptionsFlow):
@@ -29,37 +40,47 @@ class AmbeoOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         errors = {}
         host_default = self.config_entry.options.get(
-            CONFIG_HOST, self.config_entry.data.get(CONFIG_HOST))
+            CONFIG_HOST, self.config_entry.data.get(CONFIG_HOST)
+        )
         if user_input is not None:
-            name, serial, error = await validate_connection(self.hass, user_input[CONFIG_HOST])
+            _name, _serial, error = await validate_connection(
+                self.hass, user_input[CONFIG_HOST]
+            )
             if error is not None:
                 errors["base"] = error
                 return self.display_form(errors, host_default)
-            else:
-                return self.async_create_entry(data=user_input)
+            return self.async_create_entry(data=user_input)
 
         return self.display_form(errors, host_default)
 
     def display_form(self, errors, host_default):
-
         try:
-            support_debounce = self.hass.data[DOMAIN][self.config_entry.entry_id]["api"].support_debounce_mode(
-            )
-        except:
+            support_debounce = self.hass.data[DOMAIN][self.config_entry.entry_id][
+                "api"
+            ].support_debounce_mode()
+        except Exception:
             support_debounce = False
 
         if self.config_entry.options.get(CONFIG_DEBOUNCE_COOLDOWN, 0) > 0:
             errors["base"] = "experimental_feature_activated"
-        options_schema = vol.Schema({
-            vol.Optional(CONFIG_HOST, default=host_default): str,
-            vol.Optional(CONFIG_DEBOUNCE_COOLDOWN, default=self.config_entry.options.get(CONFIG_DEBOUNCE_COOLDOWN, CONFIG_DEBOUNCE_COOLDOWN_DEFAULT)): int,
-        }) if support_debounce else vol.Schema({
-            vol.Optional(CONFIG_HOST, default=host_default): str})
+        options_schema = (
+            vol.Schema(
+                {
+                    vol.Optional(CONFIG_HOST, default=host_default): str,
+                    vol.Optional(
+                        CONFIG_DEBOUNCE_COOLDOWN,
+                        default=self.config_entry.options.get(
+                            CONFIG_DEBOUNCE_COOLDOWN, CONFIG_DEBOUNCE_COOLDOWN_DEFAULT
+                        ),
+                    ): int,
+                }
+            )
+            if support_debounce
+            else vol.Schema({vol.Optional(CONFIG_HOST, default=host_default): str})
+        )
 
         return self.async_show_form(
-            step_id="init",
-            data_schema=options_schema,
-            errors=errors
+            step_id="init", data_schema=options_schema, errors=errors
         )
 
 
@@ -82,17 +103,55 @@ class AmbeoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(title=name, data=user_input)
 
-        data_schema = vol.Schema({
-            vol.Required(CONFIG_HOST, default=CONFIG_HOST_DEFAULT): str
-        })
+        data_schema = vol.Schema(
+            {vol.Required(CONFIG_HOST, default=CONFIG_HOST_DEFAULT): str}
+        )
 
         return self.async_show_form(
-            step_id="user",
-            data_schema=data_schema,
-            errors=errors
+            step_id="user", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_zeroconf(self, discovery_info: ZeroconfServiceInfo):
+        """Handle zeroconf discovery of AMBEO soundbar."""
+        _LOGGER.debug("Zeroconf discovery info: %s", discovery_info)
+
+        # Extract host from discovery info
+        host = discovery_info.host
+
+        # Validate connection to discovered device
+        name, serial, error = await validate_connection(self.hass, host)
+
+        if error or not serial:
+            _LOGGER.warning(
+                "Failed to validate discovered device at %s: %s", host, error
+            )
+            return self.async_abort(reason="cannot_connect")
+
+        # Set unique ID to prevent duplicate entries
+        await self.async_set_unique_id(serial)
+        self._abort_if_unique_id_configured(updates={CONFIG_HOST: host})
+
+        # Store discovery info for confirmation step
+        self.context["title_placeholders"] = {"name": name or "AMBEO Soundbar"}
+        self._discovered_host = host
+        self._discovered_name = name
+
+        return await self.async_step_discovery_confirm()
+
+    async def async_step_discovery_confirm(self, user_input=None):
+        """Confirm discovery of AMBEO soundbar."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self._discovered_name,
+                data={CONFIG_HOST: self._discovered_host},
+            )
+
+        return self.async_show_form(
+            step_id="discovery_confirm",
+            description_placeholders={"name": self._discovered_name},
         )
 
     @staticmethod
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(_config_entry):
         """Get the options flow for this handler."""
         return AmbeoOptionsFlowHandler()

--- a/custom_components/ambeo_soundbar/manifest.json
+++ b/custom_components/ambeo_soundbar/manifest.json
@@ -2,16 +2,27 @@
   "domain": "ambeo_soundbar",
   "name": "Ambeo Soundbar",
   "codeowners": [
-    "@faizpuru"
+    "@foXaCe"
   ],
   "config_flow": true,
   "dependencies": [
-    "http"
+    "http",
+    "zeroconf"
   ],
-  "documentation": "https://github.com/faizpuru/ha-ambeo_soundbar",
+  "documentation": "https://github.com/foXaCe/ha-ambeo_soundbar",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/faizpuru/ha-ambeo_soundbar",
+  "issue_tracker": "https://github.com/foXaCe/ha-ambeo_soundbar",
   "requirements": [],
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "zeroconf": [
+    {
+      "type": "_http._tcp.local.",
+      "name": "ambeo*"
+    },
+    {
+      "type": "_airplay._tcp.local.",
+      "name": "ambeo*"
+    }
+  ]
 }


### PR DESCRIPTION
## Description

This PR adds automatic discovery of AMBEO Soundbars via Zeroconf/mDNS.

### Changes
- Add zeroconf configuration to manifest.json
- Implement async_step_zeroconf in config_flow.py
- Support both _http._tcp.local. and _airplay._tcp.local. service types

### Benefits
- Users no longer need to manually enter IP addresses
- Soundbars are automatically discovered on the network
- One-click setup from Home Assistant notifications

### Testing
- [ ] Discovery works with Soundbar Max
- [ ] Discovery works with Soundbar Plus
- [ ] Discovery works with Soundbar Mini